### PR TITLE
Fix bootstrap links on download pages

### DIFF
--- a/templates/download.html
+++ b/templates/download.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>PDF to Word Conversion - Download</title>
-    <link href="{{ url_for('static', filename='bootstrap/css/bootstrap.min.css') }}" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.0/css/bootstrap.min.css" rel="stylesheet">
     <style>
         body {
             background-color: #f8f9fa;
@@ -36,6 +36,6 @@
         <p>Your converted file is ready!</p>
         <a href="/download/{{ filename }}" class="btn btn-primary">Download</a>
     </div>
-    <script src="{{ url_for('static', filename='bootstrap/js/bootstrap.bundle.min.js') }}"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.0/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/templates/merge_pdf_download.html
+++ b/templates/merge_pdf_download.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Merge PDF - Download</title>
-    <link href="{{ url_for('static', filename='bootstrap/css/bootstrap.min.css') }}" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.0/css/bootstrap.min.css" rel="stylesheet">
     <style>
         body {
             background-color: #f8f9fa;
@@ -36,6 +36,6 @@
         <p>Your merged file is ready to download!</p>
         <a href="/download/{{ filename }}" class="btn btn-primary">Download</a>
     </div>
-    <script src="{{ url_for('static', filename='bootstrap/js/bootstrap.bundle.min.js') }}"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.0/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/templates/split_pdf_download.html
+++ b/templates/split_pdf_download.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Split PDF - Download</title>
-    <link href="{{ url_for('static', filename='bootstrap/css/bootstrap.min.css') }}" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.0/css/bootstrap.min.css" rel="stylesheet">
     <style>
         body {
             background-color: #f8f9fa;
@@ -36,6 +36,6 @@
         <p>Your split file is ready to download!</p>
         <a href="/download/{{ split_filename }}" class="btn btn-primary">Download</a>
     </div>
-    <script src="{{ url_for('static', filename='bootstrap/js/bootstrap.bundle.min.js') }}"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.0/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- use CDN bootstrap links on the download pages so the CSS and JS actually load

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684327c064048329a11bde195517c740